### PR TITLE
Prevent keyboard handler from blocking UI controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -320,6 +320,8 @@
 
     document.addEventListener('keydown',(e)=>{
       if(gameScr.hidden) return; // само во игра
+      const tag = e.target.tagName;
+      if(['INPUT','TEXTAREA','SELECT','BUTTON'].includes(tag) || e.target.isContentEditable) return;
       const key = e.key.toUpperCase();
       const ch = key.length===1 ? key : (e.key===' ' ? ' ' : (e.key==='-'?'-':''));
       if(ALLOWED.has(ch)) { e.preventDefault(); guess(ch); }


### PR DESCRIPTION
## Summary
- Ignore key presses from interactive elements so game keyboard handler doesn't interfere with buttons.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6896d9fd1f488332846ca0ef5b08f560