### PR TITLE
Improve iOS support

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,11 +3,14 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="apple-mobile-web-app-capable" content="yes" />
+  <meta name="apple-mobile-web-app-status-bar-style" content="default" />
   <title>Бесилка — Мултиплеер (МК)</title>
   <style>
     :root{ --bg:#0b1020; --panel:#121a33; --ink:#e6ecff; --muted:#9aa3c7; --accent:#6aa6ff; --good:#18c29c; --bad:#ff6b6b; --pill:#1a244a }
     *{box-sizing:border-box}
-    body{margin:0;font-family:system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif;background:radial-gradient(1200px 600px at 70% -10%,#1a254d 0%,var(--bg) 60%);color:var(--ink);min-height:100vh;display:grid;place-items:center;padding:20px}
+    button{-webkit-tap-highlight-color:transparent;-webkit-user-select:none}
+    body{margin:0;font-family:system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif;background:radial-gradient(1200px 600px at 70% -10%,#1a254d 0%,var(--bg) 60%);color:var(--ink);min-height:100vh;display:grid;place-items:center;padding-top:calc(20px + env(safe-area-inset-top));padding-bottom:calc(20px + env(safe-area-inset-bottom));padding-left:calc(20px + env(safe-area-inset-left));padding-right:calc(20px + env(safe-area-inset-right))}
     .wrap{width:min(1000px,100%)}
     header{text-align:center;margin-bottom:14px}
     header h1{margin:0;font-size:clamp(22px,4vw,36px)}
@@ -32,6 +35,7 @@
     .pill.med .dot{background:#ffcc66}
     .pill.slow .dot{background:#ff6b6b}
     .keyboard{display:grid;grid-template-columns:repeat(11,1fr);gap:8px}
+    @media(max-width:768px){.keyboard{grid-template-columns:repeat(10,1fr)}}
     @media(max-width:520px){.keyboard{grid-template-columns:repeat(8,1fr)}}
     .keyboard button{background:#1a244a;border:1px solid rgba(255,255,255,.08);color:var(--ink);border-radius:10px;padding:10px 0;font-weight:700;cursor:pointer;transition:transform .05s ease,background .2s ease,opacity .2s ease}
     .keyboard button:active{transform:translateY(1px)}
@@ -63,7 +67,7 @@
     <section id="screen-lobby" class="panel" aria-label="Лоби">
       <h2 style="margin-top:0">1) Додади играчи</h2>
       <div class="row" style="margin-bottom:8px">
-        <input id="playerName" type="text" placeholder="Име на играч" />
+        <input id="playerName" type="text" placeholder="Име на играч" autocorrect="off" autocapitalize="none" spellcheck="false" />
         <button id="addPlayer">Додај</button>
         <button id="startGame" title="Започни нова партија" disabled>Започни</button>
       </div>
@@ -81,11 +85,11 @@
       <h2 style="margin-top:0">2) Таен збор</h2>
       <p>Сетач: <b id="setterName">—</b></p>
       <div class="row" style="margin-bottom:8px">
-        <input id="secretWord" type="text" placeholder="Внеси таен збор (македонски)" />
+        <input id="secretWord" type="text" placeholder="Внеси таен збор (македонски)" autocorrect="off" autocapitalize="none" spellcheck="false" />
         <button id="toggleSecret">Сокриј</button>
       </div>
       <div class="row" style="margin-bottom:8px">
-        <input id="hintInput" type="text" placeholder="(Опционално) Трага/категорија" />
+        <input id="hintInput" type="text" placeholder="(Опционално) Трага/категорија" autocorrect="off" autocapitalize="none" spellcheck="false" />
         <button id="beginRound">Започни рунда</button>
       </div>
       <div class="hint">Дозволени се букви, празнини и цртички. Зборот автоматски се претвора во ГОЛЕМИ БУКВИ.</div>
@@ -291,7 +295,7 @@
       kbEl.innerHTML = '';
       ABC_MK.concat(['-',' ']).forEach(l=>{
         const b = document.createElement('button'); b.textContent = l===' ' ? '␣' : l; b.dataset.key = l;
-        b.addEventListener('click', ()=> guess(l)); kbEl.appendChild(b);
+        b.addEventListener('pointerdown', ()=> guess(l)); kbEl.appendChild(b);
       });
     }
     function renderWord(){
@@ -422,6 +426,7 @@
     });
 
     // ———————————————— Иницијализација ————————————————
+    if ('serviceWorker' in navigator) { navigator.serviceWorker.register('sw.js'); }
     loadScores();
     renderPlayers();
     renderScores();

--- a/sw.js
+++ b/sw.js
@@ -1,0 +1,13 @@
+self.addEventListener('install', event => {
+  event.waitUntil(
+    caches.open('hangman-cache-v1').then(cache =>
+      cache.addAll(['./','./index.html'])
+    )
+  );
+});
+
+self.addEventListener('fetch', event => {
+  event.respondWith(
+    caches.match(event.request).then(response => response || fetch(event.request))
+  );
+});


### PR DESCRIPTION
## Summary
- Add iOS PWA meta tags and safe-area padding
- Disable autocorrect and highlight for inputs and buttons
- Use pointer events and service worker for better mobile behavior

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6896dd6451ac83328128064beacf802e