### PR TITLE
feat: improve service worker caching

### DIFF
--- a/sw.js
+++ b/sw.js
@@ -1,13 +1,40 @@
+const CACHE_NAME = 'cache-v2';
+const ASSETS = [
+  '/',
+  '/index.html',
+  '/sw.js',
+  '/icons/icon-192x192.png',
+  '/icons/icon-512x512.png'
+];
+
 self.addEventListener('install', event => {
   event.waitUntil(
-    caches.open('hangman-cache-v1').then(cache =>
-      cache.addAll(['./','./index.html'])
+    caches.open(CACHE_NAME).then(cache => cache.addAll(ASSETS))
+  );
+});
+
+self.addEventListener('activate', event => {
+  event.waitUntil(
+    caches.keys().then(keys =>
+      Promise.all(
+        keys.filter(key => key !== CACHE_NAME).map(key => caches.delete(key))
+      )
     )
   );
 });
 
 self.addEventListener('fetch', event => {
   event.respondWith(
-    caches.match(event.request).then(response => response || fetch(event.request))
+    caches.match(event.request).then(cached => {
+      if (cached) return cached;
+      return fetch(event.request).then(response => {
+        if (response && response.status === 200 && response.type === 'basic') {
+          const clone = response.clone();
+          caches.open(CACHE_NAME).then(cache => cache.put(event.request, clone));
+        }
+        return response;
+      }).catch(() => caches.match('/index.html'));
+    })
   );
 });
+


### PR DESCRIPTION
## Summary
- cache app assets with a versioned cache and activate cleanup
- add cache-first fetch handler with network and offline fallback

## Testing
- `node --check sw.js`


------
https://chatgpt.com/codex/tasks/task_e_68978d3481508332972352977d8f0e8e